### PR TITLE
Accept ES6 Promise instances and non-Promise functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
+sudo: false

--- a/index.js
+++ b/index.js
@@ -48,7 +48,11 @@ PSemaphore.prototype._assignRoom = function(room) {
   var worker = this.queue.shift();
   this.active[room] = worker;
 
-  worker()
+  // not calling worker() directly here has the advantage that worker()
+  // does not necessarily have to return a bluebird-style Promise,
+  // or even a Promise instance at all
+  Promise.resolve()
+  .then(worker)
   .then(function(v) {
     worker.Promise.resolve(v);
   }.bind(this))

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "author": "Sam Saccone",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "2.4.2"
+    "bluebird": "3.1.1"
   },
   "devDependencies": {
-    "chai-as-promised": "4.1.1",
-    "chai": "1.10.0",
-    "mocha": "2.1.0",
-    "lodash": "2.4.1"
+    "chai-as-promised": "5.1.0",
+    "chai": "3.4.1",
+    "mocha": "2.3.4",
+    "lodash": "3.10.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -20,11 +20,29 @@ describe("default semapore", function() {
     this.semapore.add(Promise.delay.bind(this, 1)).then(done)
   });
 
+  if (typeof global.Promise !== 'undefined') {
+    it("works with ES6 Promise instances", function(done) {
+      // essentially the README example
+      this.semapore.add(function() {
+        return global.Promise.resolve();
+      }).then(done)
+    });
+  }
+
   it("returns the work value", function(done) {
     this.semapore.add(function() {
       return Promise.delay(20).then(function() {
         return "hi mom";
       })
+    }).then(function(v) {
+      v.should.eql('hi mom');
+      done();
+    });
+  });
+
+  it("returns the work value when used in non-promise fashion", function(done) {
+    this.semapore.add(function() {
+      return "hi mom";
     }).then(function(v) {
       v.should.eql('hi mom');
       done();
@@ -108,7 +126,7 @@ describe("multiroom semapore", function() {
     .then(done)
   });
 
-  it("handles more jobs then rooms", function(done) {
+  it("handles more jobs than rooms", function(done) {
     _.times(5, function() {
       this.semapore.add(Promise.delay.bind(this, 100));
     }, this);

--- a/test/index.js
+++ b/test/index.js
@@ -16,36 +16,34 @@ describe("default semapore", function() {
     this.semapore.add(Promise.delay.bind(this, 1)).should.be.defined;
   });
 
-  it("resolves a single item", function(done) {
-    this.semapore.add(Promise.delay.bind(this, 1)).then(done)
+  it("resolves a single item", function() {
+    return this.semapore.add(Promise.delay.bind(this, 1));
   });
 
   if (typeof global.Promise !== 'undefined') {
-    it("works with ES6 Promise instances", function(done) {
+    it("works with ES6 Promise instances", function() {
       // essentially the README example
-      this.semapore.add(function() {
+      return this.semapore.add(function() {
         return global.Promise.resolve();
-      }).then(done)
+      });
     });
   }
 
-  it("returns the work value", function(done) {
-    this.semapore.add(function() {
+  it("returns the work value", function() {
+    return this.semapore.add(function() {
       return Promise.delay(20).then(function() {
         return "hi mom";
       })
     }).then(function(v) {
       v.should.eql('hi mom');
-      done();
     });
   });
 
-  it("returns the work value when used in non-promise fashion", function(done) {
-    this.semapore.add(function() {
+  it("returns the work value when used in non-promise fashion", function() {
+    return this.semapore.add(function() {
       return "hi mom";
     }).then(function(v) {
       v.should.eql('hi mom');
-      done();
     });
   });
 
@@ -111,27 +109,25 @@ describe("multiroom semapore", function() {
     this.semapore = new PSemaphore({rooms: 3});
   });
 
-  it("resolves a single item", function(done) {
-    this.semapore.add(function() {
+  it("resolves a single item", function() {
+    return this.semapore.add(function() {
       return Promise.delay(1);
-    }).then(done)
+    })
   });
 
-  it("fills all rooms with items", function(done) {
+  it("fills all rooms with items", function() {
     _.times(2, function() {
       this.semapore.add(Promise.delay.bind(this, 100));
     }, this);
 
-    this.semapore.add(Promise.delay.bind(this, 100))
-    .then(done)
+    return this.semapore.add(Promise.delay.bind(this, 100))
   });
 
-  it("handles more jobs than rooms", function(done) {
+  it("handles more jobs than rooms", function() {
     _.times(5, function() {
       this.semapore.add(Promise.delay.bind(this, 100));
     }, this);
 
-    this.semapore.add(Promise.delay.bind(this, 100))
-    .then(done)
+    return this.semapore.add(Promise.delay.bind(this, 100))
   });
 });


### PR DESCRIPTION
Support things like `PSemaphore.add(() => Promise.resolve(42))` where `Promise` is the global ES6 Promise object, or even just `PSemaphore.add(() => 42)`. This essentially makes the example from the README work out of the box.

This PR contains some meta stuff like Travis CI and Dependency updates; Feel free to cherry-pick c7df820 out, if you don’t want the rest of the changes (Including Node.js >= v4 in Travis CI is necessary in order to test the ES6 Promise support there, though).
